### PR TITLE
Changed QueuedResponse to use a YAML and deserializeXml

### DIFF
--- a/config/serializer/response/QueuedResponse.yaml
+++ b/config/serializer/response/QueuedResponse.yaml
@@ -1,0 +1,19 @@
+SandwaveIo\Office365\Response\QueuedResponse:
+  exclusion_policy: ALL
+
+  properties:
+
+    success:
+      expose: true
+      type: bool
+      serialized_name: IsSuccess
+
+    errorMessage:
+      expose: true
+      type: string
+      serialized_name: ErrorMessage
+
+    errorCode:
+      expose: true
+      type: int
+      serialized_name: ErrorCode

--- a/src/Components/Customer.php
+++ b/src/Components/Customer.php
@@ -84,17 +84,13 @@ final class Customer extends AbstractComponent
 
         $route = $this->getRouter()->get('customer_create');
         $response = $this->getClient()->request($route->method(), $route->url(), $document);
-
-        $xml = simplexml_load_string($response->getBody()->getContents());
+        $body = $response->getBody()->getContents();
+        $xml = simplexml_load_string($body);
 
         if ($xml === false) {
             throw new Office365Exception(self::class . ':create unable to create customer entity.');
         }
 
-        return new QueuedResponse(
-            (string) $xml->IsSuccess === 'true',
-            (string) $xml->ErrorMessage,
-            (int) $xml->ErrorCode
-        );
+        return EntityHelper::deserializeXml(QueuedResponse::class, $body);
     }
 }


### PR DESCRIPTION
To keep the code consistent I added a YAML for QueuedResponse so we can use the serialiser to deserialise this object when parsing incoming responses.  