### PR TITLE
Test cleanup + terminate fix

### DIFF
--- a/tests/Integration/Component/TerminateTest.php
+++ b/tests/Integration/Component/TerminateTest.php
@@ -25,7 +25,7 @@ final class TerminateTest extends TestCase
         $officeClient = new OfficeClient('example.com', 'test', 'test', ['handler' => $stack]);
 
         $terminateResponse = $officeClient->order->terminate(
-            '12345',
+            'OID330',
             new DateTime('NOW'),
             true,
             '123'

--- a/tests/Integration/Data/Request/TerminateRequest.xml
+++ b/tests/Integration/Data/Request/TerminateRequest.xml
@@ -4,7 +4,7 @@
         <PartnerReference>21139</PartnerReference>
         <DateCreated>2014-06-20T14:37:00</DateCreated>
     </Header>
-    <OrderId>sandwave12345</OrderId>
+    <OrderId>OID330</OrderId>
     <DesiredTerminateDate>2014-06-20</DesiredTerminateDate>
     <TerminateAsSoonAsPossible>true</TerminateAsSoonAsPossible>
 </TerminateOrderRequest_V2>

--- a/tests/Integration/Webhook/CloudAgreementTest.php
+++ b/tests/Integration/Webhook/CloudAgreementTest.php
@@ -28,7 +28,7 @@ final class CloudAgreementTest extends TestCase
         );
 
         Assert::assertInstanceOf(CloudAgreementContact::class, $cloudAgreement);
-        Assert::assertSame($cloudAgreement->getCustomerId(), 1);
+        Assert::assertSame(1, $cloudAgreement->getCustomerId());
         Assert::assertInstanceOf(PartnerReferenceHeader::class, $cloudAgreement->getHeader());
         Assert::assertInstanceOf(AgreementContact::class, $cloudAgreement->getContact());
     }
@@ -48,8 +48,8 @@ final class CloudAgreementTest extends TestCase
         $client->webhook->addEventSubscriber(Event::CLOUD_AGREEMENT_CREATE, new class() implements ContactObserverInterface {
             public function execute(CloudAgreementContact $agreementContact): void
             {
-                Assert::assertEquals('john', $agreementContact->getContact()->getFirstName());
-                Assert::assertEquals('doe', $agreementContact->getContact()->getLastName());
+                Assert::assertSame('john', $agreementContact->getContact()->getFirstName());
+                Assert::assertSame('doe', $agreementContact->getContact()->getLastName());
             }
         });
 

--- a/tests/Integration/Webhook/CloudLicenseAddonTest.php
+++ b/tests/Integration/Webhook/CloudLicenseAddonTest.php
@@ -26,9 +26,9 @@ final class CloudLicenseAddonTest extends TestCase
         );
 
         Assert::assertInstanceOf(Addon::class, $addon);
-        Assert::assertSame($addon->getParentOrderId(), 12345);
-        Assert::assertSame($addon->getProductCode(), 'sandwave1');
-        Assert::assertSame($addon->getQuantity(), 38);
+        Assert::assertSame(12345, $addon->getParentOrderId());
+        Assert::assertSame('sandwave1', $addon->getProductCode());
+        Assert::assertSame(38, $addon->getQuantity());
     }
 
     /**
@@ -46,7 +46,7 @@ final class CloudLicenseAddonTest extends TestCase
         $client->webhook->addEventSubscriber(Event::CLOUD_LICENSE_ADDON_CREATE, new class() implements AddonObserverInterface {
             public function execute(Addon $addon): void
             {
-                Assert::assertEquals('sandwave1', $addon->getProductCode());
+                Assert::assertSame('sandwave1', $addon->getProductCode());
             }
         });
 

--- a/tests/Integration/Webhook/CloudLicenseOrderTest.php
+++ b/tests/Integration/Webhook/CloudLicenseOrderTest.php
@@ -23,11 +23,11 @@ final class CloudLicenseOrderTest extends TestCase
         /** @var CloudLicense $license */
         $license = EntityHelper::createFromXML((string) file_get_contents(__DIR__ . '/../Data/Request/NewCloudLicenseOrderRequest.xml'));
         Assert::assertInstanceOf(CloudLicense::class, $license);
-        Assert::assertSame($license->getCloudTenant()->getName(), 'JohnDoe');
-        Assert::assertSame($license->getCloudTenant()->getAgreementContact()->getFirstName(), 'Jane');
+        Assert::assertSame('JohnDoe', $license->getCloudTenant()->getName());
+        Assert::assertSame('Jane', $license->getCloudTenant()->getAgreementContact()->getFirstName());
 
         if ($license->getHeader() !== null) {
-            Assert::assertSame($license->getHeader()->getPartnerReference(), '12345');
+            Assert::assertSame('12345', $license->getHeader()->getPartnerReference());
         }
     }
 
@@ -43,7 +43,7 @@ final class CloudLicenseOrderTest extends TestCase
         $client->webhook->addEventSubscriber(Event::CLOUD_LICENSE_ORDER_CREATE, new class() implements CloudLicenseObserverInterface {
             public function execute(CloudLicense $license): void
             {
-                Assert::assertEquals('JohnDoe', $license->getCloudTenant()->getName());
+                Assert::assertSame('JohnDoe', $license->getCloudTenant()->getName());
             }
         });
 

--- a/tests/Integration/Webhook/CustomerTest.php
+++ b/tests/Integration/Webhook/CustomerTest.php
@@ -20,23 +20,23 @@ final class CustomerTest extends TestCase
         );
 
         Assert::assertInstanceOf(Customer::class, $customer);
-        Assert::assertSame($customer->getName(), 'Naam Klant');
-        Assert::assertSame($customer->getStreet(), 'StraatNaam');
-        Assert::assertSame($customer->getHouseNr(), 38);
-        Assert::assertSame($customer->getHouseNrExtension(), '');
-        Assert::assertSame($customer->getZipCode(), '1234AB');
-        Assert::assertSame($customer->getCity(), 'Amsterdam');
-        Assert::assertSame($customer->getCountryCode(), 'NLD');
-        Assert::assertSame($customer->getPhone1(), '0612345678');
-        Assert::assertSame($customer->getPhone2(), null);
-        Assert::assertSame($customer->getFax(), null);
-        Assert::assertSame($customer->getEmail(), 'klant@email.nl');
-        Assert::assertSame($customer->getWebsite(), '');
-        Assert::assertSame($customer->getDebitNr(), '');
-        Assert::assertSame($customer->getIban(), null);
-        Assert::assertSame($customer->getBic(), null);
-        Assert::assertSame($customer->getLegalStatus(), 'CV');
-        Assert::assertSame($customer->getExternalId(), null);
-        Assert::assertSame($customer->getChamberOfCommerceNr(), null);
+        Assert::assertSame('Naam Klant', $customer->getName());
+        Assert::assertSame('StraatNaam', $customer->getStreet());
+        Assert::assertSame(38, $customer->getHouseNr());
+        Assert::assertSame('', $customer->getHouseNrExtension());
+        Assert::assertSame('1234AB', $customer->getZipCode());
+        Assert::assertSame('Amsterdam', $customer->getCity());
+        Assert::assertSame('NLD', $customer->getCountryCode());
+        Assert::assertSame('0612345678', $customer->getPhone1());
+        Assert::assertSame(null, $customer->getPhone2());
+        Assert::assertSame(null, $customer->getFax());
+        Assert::assertSame('klant@email.nl', $customer->getEmail());
+        Assert::assertSame('', $customer->getWebsite());
+        Assert::assertSame('', $customer->getDebitNr());
+        Assert::assertSame(null, $customer->getIban());
+        Assert::assertSame(null, $customer->getBic());
+        Assert::assertSame('CV', $customer->getLegalStatus());
+        Assert::assertSame(null, $customer->getExternalId());
+        Assert::assertSame(null, $customer->getChamberOfCommerceNr());
     }
 }

--- a/tests/Integration/Webhook/OrderModifyQuantityTest.php
+++ b/tests/Integration/Webhook/OrderModifyQuantityTest.php
@@ -23,7 +23,7 @@ final class OrderModifyQuantityTest extends TestCase
         /** @var OrderModifyQuantity $modification */
         $modification = EntityHelper::createFromXML((string) file_get_contents(__DIR__ . '/../Data/Request/OrderModifyQuantityRequest.xml'));
         Assert::assertInstanceOf(OrderModifyQuantity::class, $modification);
-        Assert::assertSame($modification->getQuantity(), 4);
+        Assert::assertSame(4, $modification->getQuantity());
 
         if ($modification->getHeader() !== null) {
             Assert::assertSame($modification->getHeader()->getPartnerReference(), '12345');
@@ -45,12 +45,12 @@ final class OrderModifyQuantityTest extends TestCase
         $client->webhook->addEventSubscriber(Event::ORDER_MODIFY_QUANTITY, new class() implements OrderModifyQuantityObserverInterface {
             public function execute(OrderModifyQuantity $modifyQuantity): void
             {
-                Assert::assertEquals(4, $modifyQuantity->getQuantity());
-                Assert::assertEquals(123, $modifyQuantity->getOrderId());
+                Assert::assertSame(4, $modifyQuantity->getQuantity());
+                Assert::assertSame(123, $modifyQuantity->getOrderId());
                 Assert::assertTrue($modifyQuantity->isDelta());
 
                 if ($modifyQuantity->getHeader() !== null) {
-                    Assert::assertEquals('12345', $modifyQuantity->getHeader()->getPartnerReference());
+                    Assert::assertSame('12345', $modifyQuantity->getHeader()->getPartnerReference());
                 }
             }
         });

--- a/tests/Integration/Webhook/TerminateTest.php
+++ b/tests/Integration/Webhook/TerminateTest.php
@@ -26,9 +26,9 @@ final class TerminateTest extends TestCase
         );
 
         Assert::assertInstanceOf(Terminate::class, $terminate);
-        Assert::assertSame($terminate->getOrderId(), 'sandwave12345');
-        Assert::assertSame($terminate->getDesiredTerminateDate()->format('Y-m-d'), '2014-06-20');
-        Assert::assertSame($terminate->getTerminateAsSoonAsPossible(), true);
+        Assert::assertSame('OID330', $terminate->getOrderId());
+        Assert::assertSame('2014-06-20', $terminate->getDesiredTerminateDate()->format('Y-m-d'));
+        Assert::assertTrue($terminate->getTerminateAsSoonAsPossible());
     }
 
     /**
@@ -46,12 +46,12 @@ final class TerminateTest extends TestCase
         $client->webhook->addEventSubscriber(Event::TERMINATE_ORDER, new class() implements TerminateObserverInterface {
             public function execute(Terminate $terminate): void
             {
-                Assert::assertEquals('sandwave12345', $terminate->getOrderId());
+                Assert::assertSame('OID330', $terminate->getOrderId());
                 Assert::assertTrue($terminate->getTerminateAsSoonAsPossible());
                 Assert::assertSame('2014-06-20', $terminate->getDesiredTerminateDate()->format('Y-m-d'));
 
                 if ($terminate->getHeader() !== null) {
-                    Assert::assertEquals('21139', $terminate->getHeader()->getPartnerReference());
+                    Assert::assertSame('21139', $terminate->getHeader()->getPartnerReference());
                 }
             }
         });


### PR DESCRIPTION
Replaces assertequals (==) with assertsame (===)
Fixes the assert to expected, actual instead of random like we had before
Fixes orderid problem with terminate