### PR TITLE
Removed check for messages 

### DIFF
--- a/tests/Integration/Component/OrderModifyQuantityTest.php
+++ b/tests/Integration/Component/OrderModifyQuantityTest.php
@@ -28,7 +28,6 @@ final class OrderModifyQuantityTest extends TestCase
 
         Assert::assertInstanceOf(QueuedResponse::class, $response);
         Assert::assertTrue($response->isSuccess());
-        Assert::assertSame('Success', $response->getErrorMessage());
         Assert::assertSame(0, $response->getErrorCode());
     }
 }


### PR DESCRIPTION
Because this request does not return a message in it’s QueuedResponse.
If this is being checked it will cause an error saying message is uninitialised because the API doesn't actually return a message.
