### PR TITLE
Remove name parameter from customer agreement.

### DIFF
--- a/src/Components/Contact/Agreement.php
+++ b/src/Components/Contact/Agreement.php
@@ -20,12 +20,12 @@ final class Agreement extends AbstractComponent
         string $phoneNumber,
         \DateTime $agreed
     ): AgreementContact {
-        $agreement = EntityHelper::deserialize(AgreementContact::class, AgreementContactDataTransformer::transform(...func_get_args()));
+        $agreementContact = EntityHelper::deserialize(AgreementContact::class, AgreementContactDataTransformer::transform(...func_get_args()));
 
-        if ($agreement === null) {
+        if ($agreementContact === null) {
             throw new Office365Exception(self::class . ':create Tenant could not be created');
         }
 
-        return $agreement;
+        return $agreementContact;
     }
 }

--- a/src/Components/Contact/Agreement.php
+++ b/src/Components/Contact/Agreement.php
@@ -14,19 +14,18 @@ final class Agreement extends AbstractComponent
      * @throws Office365Exception
      */
     public function create(
-        string $name,
         string $firstname,
         string $lastname,
         string $email,
         string $phoneNumber,
         \DateTime $agreed
     ): AgreementContact {
-        $tenant = EntityHelper::deserialize(AgreementContact::class, AgreementContactDataTransformer::transform(...func_get_args()));
+        $agreement = EntityHelper::deserialize(AgreementContact::class, AgreementContactDataTransformer::transform(...func_get_args()));
 
-        if ($tenant === null) {
+        if ($agreement === null) {
             throw new Office365Exception(self::class . ':create Tenant could not be created');
         }
 
-        return $tenant;
+        return $agreement;
     }
 }

--- a/src/Transformer/AgreementContactDataTransformer.php
+++ b/src/Transformer/AgreementContactDataTransformer.php
@@ -8,7 +8,6 @@ final class AgreementContactDataTransformer
      * @return string[]
      */
     public static function transform(
-        string $name,
         string $firstname,
         string $lastname,
         string $email,

--- a/src/Transformer/AgreementContactDataTransformer.php
+++ b/src/Transformer/AgreementContactDataTransformer.php
@@ -16,7 +16,6 @@ final class AgreementContactDataTransformer
         \DateTime $agreed
     ): array {
         return [
-            'TenantName' => $name,
             'FirstName' => $firstname,
             'LastName' => $lastname,
             'EmailAddress' => $email,

--- a/tests/Integration/Component/CloudLicenseOrderTest.php
+++ b/tests/Integration/Component/CloudLicenseOrderTest.php
@@ -31,7 +31,6 @@ final class CloudLicenseOrderTest extends TestCase
             'john@doe.com'
         );
         $contact = $officeClient->contact->agreement->create(
-            'sandwave test',
             'john',
             'doe',
             'john@doe.com',


### PR DESCRIPTION
When creating a customer agreement the function had a name parameter. It also has the firstname and lastname parameter. The name was not needed, it is not in the entity and also RoutIT doesn't want it.

It was still in the function call but after that nothing was done with it, so let's remove it.