### PR TITLE
Added defaults argument values to summary function

### DIFF
--- a/config/serializer/OrderSummary.yaml
+++ b/config/serializer/OrderSummary.yaml
@@ -24,6 +24,11 @@ SandwaveIo\Office365\Entity\OrderSummary:
       type: string
       serialized_name: ProductName
 
+    quantity:
+      expose: true
+      type: string
+      serialized_name: Quantity
+
     dateActiveFrom:
       expose: true
       type: DateTime<'Y-m-d\TH:i:s'>

--- a/src/Components/Order/Order.php
+++ b/src/Components/Order/Order.php
@@ -99,18 +99,18 @@ final class Order extends AbstractComponent
      * @throws Office365Exception
      */
     public function summary(
-        ?int $customerId,
-        ?string $orderState,
-        ?string $productGroup,
-        ?string $productName,
-        ?DateTime $dateActiveFrom,
-        ?DateTime $dateActiveTo,
-        ?DateTime $dateModifiedFrom,
-        ?DateTime $dateModifiedTo,
-        ?string $label,
-        ?string $attribute,
-        ?int $skip,
-        ?int $take
+        ?int $customerId = null,
+        ?string $orderState = null,
+        ?string $productGroup = null,
+        ?string $productName = null,
+        ?DateTime $dateActiveFrom = null,
+        ?DateTime $dateActiveTo = null,
+        ?DateTime $dateModifiedFrom = null,
+        ?DateTime $dateModifiedTo = null,
+        ?string $label = null,
+        ?string $attribute = null,
+        ?int $skip = null,
+        ?int $take = null
     ): OrderSummaryResponse {
         $summaryData = OrderSummaryBuilder::build(
             ... func_get_args()

--- a/src/Entity/OrderSummary.php
+++ b/src/Entity/OrderSummary.php
@@ -30,6 +30,8 @@ final class OrderSummary implements EntityInterface
 
     private ?int $take = null;
 
+    private ?int $quantity = null;
+
     public function getCustomerId(): ?int
     {
         return $this->customerId;
@@ -88,5 +90,10 @@ final class OrderSummary implements EntityInterface
     public function getTake(): ?int
     {
         return $this->take;
+    }
+
+    public function getQuantity(): int
+    {
+        return $this->quantity;
     }
 }

--- a/tests/Integration/Component/OrderSummaryTest.php
+++ b/tests/Integration/Component/OrderSummaryTest.php
@@ -44,5 +44,6 @@ final class OrderSummaryTest extends TestCase
         Assert::assertSame(25, $response->getPagedResult()->getTotal());
         Assert::assertSame(1, count($response->getPagedResult()->getResults()));
         Assert::assertSame('Activate', $response->getPagedResult()->getResults()[0]->getOrderState());
+        Assert::assertSame(10, $response->getPagedResult()->getResults()[0]->getQuantity());
     }
 }


### PR DESCRIPTION
 because they are all optional according to the documentation.