### PR TITLE
Customer modify add partnerreference

### DIFF
--- a/src/Components/Customer.php
+++ b/src/Components/Customer.php
@@ -116,7 +116,8 @@ final class Customer extends AbstractComponent
         ?string $vatNr,
         string $legalStatus,
         ?string $externalId,
-        ?string $chamberOfCommerceNr
+        ?string $chamberOfCommerceNr,
+        string $partnerReference
     ): QueuedResponse {
         $customerData = CustomerDataBuilder::build(
             ... func_get_args()


### PR DESCRIPTION
Add partnerreference to the customer modify. Fixes the insufficient argument error.