### PR TITLE
Guzzle absolute urls bug fix

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,49 +1,49 @@
 customer:
   create:
     method: post
-    url: '/queued'
+    url: 'queued'
 
   modify:
     method: post
-    url: '/queued'
+    url: 'queued'
 
   has_domain_ownership:
     method: post
-    url: '/realtime'
+    url: 'realtime'
 
 order:
   license_create:
     method: post
-    url: '/queued'
+    url: 'queued'
 
   modify:
     method: post
-    url: '/queued'
+    url: 'queued'
 
   summary:
     method: post
-    url: '/realtime'
+    url: 'realtime'
 
 addon:
   create:
     method: post
-    url: '/queued'
+    url: 'queued'
 
 terminate:
   order:
     method: post
-    url: '/queued'
+    url: 'queued'
 
 summary:
   order:
     method: post
-    url: '/realtime'
+    url: 'realtime'
 
 tenant:
   exists:
     method: post
-    url: '/realtime'
+    url: 'realtime'
 
   fetch_tenant:
     method: post
-    url: '/realtime'
+    url: 'realtime'


### PR DESCRIPTION
Guzzle ignores the path (/api/) for example when it has an absolute url.

Now it properly appends the route url.

See: https://www.rfc-editor.org/rfc/rfc3986#section-5.2

Tested locally:

![Screenshot 2024-05-13 at 14 46 29](https://github.com/sandwave-io/office-365/assets/57816876/8943e151-c361-471b-b9e9-ddb08a57b2bf)
